### PR TITLE
Add layout referencing to image selection action map

### DIFF
--- a/src/studio/actions/imageSelection.js
+++ b/src/studio/actions/imageSelection.js
@@ -11,7 +11,10 @@ export function imageSelectionScript(debug) {
 
     const layoutName = getSelectedLayoutName();
 
-    const layoutImageMapping = imageSelectionData[layoutName];
+    let layoutImageMapping = imageSelectionData[layoutName];
+    if (layoutImageMapping.ref == true) {
+      layoutImageMapping = imageSelectionData[layoutImageMapping.refTo];
+    }
 
     if (debug) {
       debugData.imageVars = imageVars;

--- a/src/studio/studioAdapter.ts
+++ b/src/studio/studioAdapter.ts
@@ -282,7 +282,13 @@ export async function saveLayoutMappingToAction(
   layoutMaps: LayoutMap[],
   doc: Doc,
 ) {
-  const actionMap = layoutMappingToActionMap(layoutMaps, doc);
+  const actionMapResult = layoutMappingToActionMap(layoutMaps, doc);
+ 
+  if (actionMapResult.isError()) {
+    return actionMapResult;
+  }
+
+  const actionMap = actionMapResult.value;
 
   const script =
     imageSelectionScript


### PR DESCRIPTION
- **feat:** Implement `ref` and `refTo` properties in the `imageSelectionData` structure.
  - If a layout's mapping has `ref: true`, the `imageSelectionScript` will now look up the mapping from the layout specified in `refTo`.
- **feat:** Update `layoutMappingToActionMap` to support layout referencing.
  - When multiple `layoutIds` are present in a `LayoutMap`, the first layout ID is used to generate the primary mapping.
  - Subsequent `layoutIds` in the same `LayoutMap` will generate entries in the `actionMap` that reference the primary layout's mapping using `ref: true` and `refTo: <primary_layout_name>`.
- **refactor:** Change `layoutMappingToActionMap` return type to `Result` for error handling.
  - This allows the function to return an `Error` if a layout ID specified in `layoutMaps` cannot be found in the `doc`.
- **chore:** Update `saveLayoutMappingToAction` to handle the `Result` type returned by `layoutMappingToActionMap`.

This change allows for more decreased file size of image selection logic across multiple layouts that share the same variable dependencies and image selection rules.