### PR TITLE
fix: support cross-directory smart crop copy/paste operations

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -70867,7 +70867,7 @@ function ImageBrowser({
     }
     if (isFile) {
       const isSelected = selectedFile === item.id;
-      const isSourceFile = smartCropMode && sourceFile === item.id;
+      const isSourceFile = smartCropMode && sourceFile?.id === item.id;
       const isTargetSelected = smartCropMode && targetSelectedFiles.has(item.id);
       const isFileSelectable = mode === 1 /* FileSelection */;
       return /* @__PURE__ */ jsx_runtime22.jsx("div", {
@@ -70902,7 +70902,7 @@ function ImageBrowser({
             children: [
               isFileSelectable && smartCropMode && !isSourceFile && /* @__PURE__ */ jsx_runtime22.jsx(Checkbox, {
                 checked: isTargetSelected,
-                onChange: () => handleTargetFileToggle(item.name),
+                onChange: () => handleTargetFileToggle(item.id),
                 onClick: (e) => e.stopPropagation()
               }),
               renderFileIcon(item),
@@ -70993,9 +70993,12 @@ function ImageBrowser({
   };
   const handleEnterSmartCropMode = () => {
     if (selectedFile) {
-      setSmartCropMode(true);
-      setSourceFile(selectedFile);
-      setTargetSelectedFiles(new Set);
+      const fileObj = files.find((f2) => f2.id === selectedFile);
+      if (fileObj) {
+        setSmartCropMode(true);
+        setSourceFile(fileObj);
+        setTargetSelectedFiles(new Set);
+      }
     }
   };
   const handleExitSmartCropMode = () => {
@@ -71078,15 +71081,11 @@ function ImageBrowser({
       }
       const token2 = (await studioResult.value.configuration.getValue("GRAFX_AUTH_TOKEN")).parsedData;
       const baseUrl = (await studioResult.value.configuration.getValue("ENVIRONMENT_API")).parsedData;
-      const sourceFileObj = files.find((f2) => f2.id === sourceFile);
-      if (!sourceFileObj) {
-        throw new Error(`Source file ${sourceFile} not found`);
-      }
-      const getVisionTaskId = `get-vision-${sourceFileObj.id}`;
+      const getVisionTaskId = `get-vision-${sourceFile.id}`;
       setCopyTasks([
         {
           id: getVisionTaskId,
-          name: `Getting vision data from: ${sourceFile}`,
+          name: `Getting vision data from: ${sourceFile.name}`,
           type: "get_vision",
           status: "processing"
         }
@@ -71094,7 +71093,7 @@ function ImageBrowser({
       const visionResult = await getVision({
         baseUrl,
         connectorId: selectedConnectorId,
-        asset: sourceFileObj.id,
+        asset: sourceFile.id,
         authorization: token2
       });
       if (!visionResult.isOk()) {
@@ -71351,9 +71350,9 @@ function ImageBrowser({
           }, folder.id);
         }),
         files.map((file2) => {
-          const isSelected = selectedFile === file2.name;
-          const isSourceFile = smartCropMode && sourceFile === file2.name;
-          const isTargetSelected = smartCropMode && targetSelectedFiles.has(file2.name);
+          const isSelected = selectedFile === file2.id;
+          const isSourceFile = smartCropMode && sourceFile?.id === file2.id;
+          const isTargetSelected = smartCropMode && targetSelectedFiles.has(file2.id);
           const isFileSelectable = mode === 1 /* FileSelection */;
           return /* @__PURE__ */ jsx_runtime22.jsxs(Card, {
             shadow: "sm",
@@ -71373,16 +71372,16 @@ function ImageBrowser({
               }
               if (smartCropMode) {
                 if (!isSourceFile) {
-                  handleTargetFileToggle(file2.name);
+                  handleTargetFileToggle(file2.id);
                 }
               } else {
-                handleFileSelection(file2.name);
+                handleFileSelection(file2.id);
               }
             },
             children: [
               isFileSelectable && smartCropMode && !isSourceFile && /* @__PURE__ */ jsx_runtime22.jsx(Checkbox, {
                 checked: isTargetSelected,
-                onChange: () => handleTargetFileToggle(file2.name),
+                onChange: () => handleTargetFileToggle(file2.id),
                 style: {
                   position: "absolute",
                   top: "8px",
@@ -81014,4 +81013,4 @@ async function checkStudioExist() {
 }
 checkStudioExist();
 
-//# debugId=5F228DB4C675DF2564756E2164756E21
+//# debugId=3FD3690C423C834E64756E2164756E21

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "studio-toolbar-plus",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "description": "A simple toolbar extension to give you more super powers in GraFx Studio",
   "icons": {
     "16": "icons/icon16.png",

--- a/src/components/ImageBrowser.tsx
+++ b/src/components/ImageBrowser.tsx
@@ -889,7 +889,7 @@ export function ImageBrowser<T extends ImageBrowserMode>({
               {isFileSelectable && smartCropMode && !isSourceFile && (
                 <Checkbox
                   checked={isTargetSelected}
-                  onChange={() => handleTargetFileToggle(item.name)}
+                  onChange={() => handleTargetFileToggle(item.id)}
                   onClick={(e) => e.stopPropagation()}
                 />
               )}
@@ -1478,10 +1478,10 @@ export function ImageBrowser<T extends ImageBrowserMode>({
         })}
 
         {files.map((file) => {
-          const isSelected = selectedFile === file.name;
-          const isSourceFile = smartCropMode && sourceFile?.id === file.name;
+          const isSelected = selectedFile === file.id;
+          const isSourceFile = smartCropMode && sourceFile?.id === file.id;
           const isTargetSelected =
-            smartCropMode && targetSelectedFiles.has(file.name);
+            smartCropMode && targetSelectedFiles.has(file.id);
 
           // In folder mode, files are not selectable
           const isFileSelectable = mode === ImageBrowserMode.FileSelection;
@@ -1520,17 +1520,17 @@ export function ImageBrowser<T extends ImageBrowserMode>({
                 }
                 if (smartCropMode) {
                   if (!isSourceFile) {
-                    handleTargetFileToggle(file.name);
+                    handleTargetFileToggle(file.id);
                   }
                 } else {
-                  handleFileSelection(file.name);
+                  handleFileSelection(file.id);
                 }
               }}
             >
               {isFileSelectable && smartCropMode && !isSourceFile && (
                 <Checkbox
                   checked={isTargetSelected}
-                  onChange={() => handleTargetFileToggle(file.name)}
+                  onChange={() => handleTargetFileToggle(file.id)}
                   style={{
                     position: "absolute",
                     top: "8px",

--- a/src/components/ImageBrowser.tsx
+++ b/src/components/ImageBrowser.tsx
@@ -133,7 +133,8 @@ export function ImageBrowser<T extends ImageBrowserMode>({
   );
   // Smart crop selection mode state
   const [smartCropMode, setSmartCropMode] = useState<boolean>(false);
-  const [sourceFile, setSourceFile] = useState<string | null>(null);
+  // Store the complete Media object instead of just the ID to support cross-directory copy/paste
+  const [sourceFile, setSourceFile] = useState<Media | null>(null);
   const [targetSelectedFiles, setTargetSelectedFiles] = useState<Set<string>>(
     new Set()
   );
@@ -836,7 +837,7 @@ export function ImageBrowser<T extends ImageBrowserMode>({
 
     if (isFile) {
       const isSelected = selectedFile === item.id;
-      const isSourceFile = smartCropMode && sourceFile === item.id;
+      const isSourceFile = smartCropMode && sourceFile?.id === item.id;
       const isTargetSelected =
         smartCropMode && targetSelectedFiles.has(item.id);
 
@@ -1000,9 +1001,13 @@ export function ImageBrowser<T extends ImageBrowserMode>({
 
   const handleEnterSmartCropMode = () => {
     if (selectedFile) {
-      setSmartCropMode(true);
-      setSourceFile(selectedFile);
-      setTargetSelectedFiles(new Set());
+      // Find the complete file object and store it to support cross-directory copy/paste
+      const fileObj = files.find((f) => f.id === selectedFile);
+      if (fileObj) {
+        setSmartCropMode(true);
+        setSourceFile(fileObj);
+        setTargetSelectedFiles(new Set());
+      }
     }
   };
 
@@ -1120,16 +1125,13 @@ export function ImageBrowser<T extends ImageBrowserMode>({
       ).parsedData as string;
 
       // Step 1: Get vision data from source file
-      const sourceFileObj = files.find((f) => f.id === sourceFile);
-      if (!sourceFileObj) {
-        throw new Error(`Source file ${sourceFile} not found`);
-      }
-
-      const getVisionTaskId = `get-vision-${sourceFileObj.id}`;
+      // sourceFile is now the complete Media object, so we can use it directly
+      // This allows cross-directory copy/paste since we don't need to look up the file in the current directory
+      const getVisionTaskId = `get-vision-${sourceFile.id}`;
       setCopyTasks([
         {
           id: getVisionTaskId,
-          name: `Getting vision data from: ${sourceFile}`,
+          name: `Getting vision data from: ${sourceFile.name}`,
           type: "get_vision",
           status: "processing",
         },
@@ -1138,7 +1140,7 @@ export function ImageBrowser<T extends ImageBrowserMode>({
       const visionResult = await getVision({
         baseUrl,
         connectorId: selectedConnectorId!,
-        asset: sourceFileObj.id,
+        asset: sourceFile.id,
         authorization: token,
       });
 
@@ -1477,7 +1479,7 @@ export function ImageBrowser<T extends ImageBrowserMode>({
 
         {files.map((file) => {
           const isSelected = selectedFile === file.name;
-          const isSourceFile = smartCropMode && sourceFile === file.name;
+          const isSourceFile = smartCropMode && sourceFile?.id === file.name;
           const isTargetSelected =
             smartCropMode && targetSelectedFiles.has(file.name);
 


### PR DESCRIPTION
Previously, copying a smart crop and then navigating to a different directory before pasting would fail with "Source file not found" error. This occurred because the code only stored the file ID when copying, then tried to look up that ID in the current directory's file list during paste.

This allows users to:
1. Copy a smart crop from a file in one directory
2. Navigate to a different directory
3. Select target files and paste the smart crop successfully

Fixes the cross-directory copy/paste bug by ensuring the source file data persists independently of the current directory context.